### PR TITLE
Fixing garbled header

### DIFF
--- a/src/main/java/org/jvnet/mimepull/MIMEConfig.java
+++ b/src/main/java/org/jvnet/mimepull/MIMEConfig.java
@@ -70,20 +70,22 @@ public class MIMEConfig {
     File tempDir;
     String prefix;
     String suffix;
+    String headerEncoding;
 
-    private MIMEConfig(boolean parseEagerly, int chunkSize,
-                       long inMemoryThreshold, String dir, String prefix, String suffix) {
+    private MIMEConfig(boolean parseEagerly, int chunkSize, long inMemoryThreshold,
+                       String dir, String prefix, String suffix, String headerEncoding) {
         this.parseEagerly = parseEagerly;
         this.chunkSize = chunkSize;
         this.memoryThreshold = inMemoryThreshold;
         this.prefix = prefix;
         this.suffix = suffix;
+        this.headerEncoding = headerEncoding;
         setDir(dir);
     }
 
     public MIMEConfig() {
         this(false, DEFAULT_CHUNK_SIZE, DEFAULT_MEMORY_THRESHOLD, null,
-                DEFAULT_FILE_PREFIX, null);
+                DEFAULT_FILE_PREFIX, null, null);
     }
 
     boolean isParseEagerly() {
@@ -131,6 +133,10 @@ public class MIMEConfig {
 
     String getTempFileSuffix() {
         return suffix;
+    }
+
+    public void setHeaderEncoding(String headerEncoding) {
+        this.headerEncoding = headerEncoding;
     }
 
     /**

--- a/src/main/java/org/jvnet/mimepull/MIMEParser.java
+++ b/src/main/java/org/jvnet/mimepull/MIMEParser.java
@@ -70,7 +70,7 @@ class MIMEParser implements Iterable<MIMEEvent> {
     private static final Logger LOGGER = Logger.getLogger(MIMEParser.class.getName());
 
     private static final String HEADER_ENCODING = "ISO8859-1";
-    
+
     // Actually, the grammar doesn't support whitespace characters
     // after boundary. But the mail implementation checks for it.
     // We will only check for these many whitespace characters after boundary
@@ -101,6 +101,7 @@ class MIMEParser implements Iterable<MIMEEvent> {
     private byte[] buf;
     private int len;
     private boolean bol;        // beginning of the line
+    private String headerEncoding;
 
     /*
      * Parses the MIME content. At the EOF, it also closes input stream
@@ -111,6 +112,7 @@ class MIMEParser implements Iterable<MIMEEvent> {
         bl = bndbytes.length;
         this.config = config;
         gss = new int[bl];
+        this.headerEncoding = config.headerEncoding != null ? config.headerEncoding : HEADER_ENCODING;
         compileBoundaryPattern();
 
         // \r\n + boundary + "--\r\n" + lots of LWSP
@@ -357,7 +359,7 @@ class MIMEParser implements Iterable<MIMEEvent> {
         return bytes;
     }
 
-        /**
+    /**
      * Boyer-Moore search method. Copied from java.util.regex.Pattern.java
      *
      * Pre calculates arrays needed to generate the bad character
@@ -512,7 +514,7 @@ NEXT:   while (off <= last) {
                 return null;
             }
 
-            String hdr = new String(buf, offset, hdrLen, HEADER_ENCODING);
+            String hdr = new String(buf, offset, hdrLen, headerEncoding);
             offset += hdrLen+lwsp;
             return hdr;
         }


### PR DESCRIPTION
Fix the issue #7 , which claimed to be fixed and closed. However the header encoding remains hardcoded at line 515 in [MIMEParser.java](https://github.com/javaee/metro-mimepull/blob/06803bd83bacee2af4252226f757a42c9a79f33d/src/main/java/org/jvnet/mimepull/MIMEParser.java). What I've done in this PR is simply adding a `headerEncoding` option in `MimeConfig` to allow overwriting the default value 'ISO8859_1' if not null.